### PR TITLE
Increase performance when repeating an execution

### DIFF
--- a/src/main/java/filegenerator/execution/Environnement.java
+++ b/src/main/java/filegenerator/execution/Environnement.java
@@ -171,6 +171,14 @@ public class Environnement {
         instance = null;
     }
 
+    public static void clearExecution() {
+        Environnement env = Environnement.getEnvironenement();
+        env.chunksMap.clear();
+        env.variableMap.clear();
+        env.promisesMap.clear();
+        env.clearOutput();
+    }
+
     public ExecutionParameters getParameters() {
         return parameters;
     }

--- a/src/main/java/filegenerator/filegenerator/FileGenerator.java
+++ b/src/main/java/filegenerator/filegenerator/FileGenerator.java
@@ -138,6 +138,7 @@ public class FileGenerator {
                 Chunk value = entry.getValue();
                 value.writeChunk(outputFolder, i);
             }
+            Environnement.clearExecution();
         }
     }
 


### PR DESCRIPTION
Clear execution information after each occurrence to avoid filling the memory